### PR TITLE
MOROFT audit fixes

### DIFF
--- a/contracts/MOROFT.sol
+++ b/contracts/MOROFT.sol
@@ -7,7 +7,7 @@ import {IMOROFT, IERC20, IERC165, IOAppCore} from "./interfaces/IMOROFT.sol";
 
 /**
  * The token is ERC20 with burnable and Layer Zero OFT features.
- * @custom:security-contact Devs@Mor.org
+ * @custom:security-contact devs@mor.org
  */
 contract MOROFT is IMOROFT, OFT {
     address private immutable _minter;
@@ -41,17 +41,18 @@ contract MOROFT is IMOROFT, OFT {
     }
 
     /**
-     * @notice The function to get the minter address.
-     * @return The minter address.
+     * @dev See {IMOROFT-minter}.
      */
     function minter() public view returns (address) {
         return _minter;
     }
 
     /**
-     * @notice The function to mint tokens.
-     * @param account_ The address of the account to mint tokens to.
-     * @param amount_ The amount of tokens to mint.
+     * @dev See {IMOROFT-mint}.
+     *
+     * Requirements:
+     * - the caller must be the `minter()` address for this contract.
+     *
      */
     function mint(address account_, uint256 amount_) public {
         require(_msgSender() == minter(), "MOROFT: invalid caller");
@@ -60,27 +61,18 @@ contract MOROFT is IMOROFT, OFT {
     }
 
     /**
-     * @notice The function to destroys `amount` tokens from the caller.
-     * See {ERC20-_burn}.
-     * @param amount_ The amount of tokens to burn.
+     * @dev See {IMOROFT-burn}.
      */
     function burn(uint256 amount_) public {
         _burn(_msgSender(), amount_);
     }
 
     /**
-     * @notice The function to destroys `amount` tokens from `account`, deducting from the caller's
-     * allowance.
-     *
-     * See {ERC20-_burn} and {ERC20-allowance}.
+     * @dev See {IMOROFT-burnFrom, ERC20-_burn, ERC20-allowance}.
      *
      * Requirements:
-     *
      * - the caller must have allowance for ``accounts``'s tokens of at least
      * `amount`.
-     *
-     * @param account_ The address of the account to burn tokens from.
-     * @param amount_ The amount of tokens to burn.
      */
     function burnFrom(address account_, uint256 amount_) public {
         _spendAllowance(account_, _msgSender(), amount_);

--- a/contracts/interfaces/IMOROFT.sol
+++ b/contracts/interfaces/IMOROFT.sol
@@ -6,11 +6,34 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IOAppCore} from ".././@layerzerolabs/lz-evm-oapp-v2/contracts/oapp/interfaces/IOAppCore.sol";
 
 interface IMOROFT is IERC20, IERC165 {
+    /**
+     * @notice The function to get the minter address.
+     * @return The minter address.
+     */
     function minter() external view returns (address);
 
+    /**
+     * @notice The function to mint tokens.
+     *
+     * @param account_ The address of the account to mint tokens to.
+     * @param amount_ The amount of tokens to mint.
+     */
     function mint(address account_, uint256 amount_) external;
 
+    /**
+     * @notice The function to destroys `amount` tokens from the caller.
+     * See {ERC20-_burn}.
+     *
+     * @param amount_ The amount of tokens to burn.
+     */
     function burn(uint256 amount_) external;
 
+    /**
+     * @notice The function to destroys `amount` tokens from `account`, deducting from the caller's
+     * allowance.
+     *
+     * @param account_ The address of the account to burn tokens from.
+     * @param amount_ The amount of tokens to burn.
+     */
     function burnFrom(address account_, uint256 amount_) external;
 }


### PR DESCRIPTION
Regarding N01: Missing Docstrings, add a comment on mint function stating that only minter role should be able to call it.

Additionally, I believe there has been a confusion on the where the docstrings should be, we wanted to have the docstring in IMOROFT interface referenced in the MOROFT contract, with an additional comment on the mint functionality. 
I don't see the need of removing docstrings from the interface which is done in this PR: https://github.com/MorpheusAIs/SmartContracts/pull/29/files#diff-7df3d98a493a8bcb1628ca6472bcf17af9f8efd67896f7db463a9a713a669358

The best way to move forward is to have the docstrings in the interface and let the inherting contracts inherit the docstrings, any additional information on function implementations should be present in the docstrings of the inheriting contract. This is not a high priority finding so I will leave it up to your team to decide how you want to proceed with this.